### PR TITLE
test for regexps before info extraction

### DIFF
--- a/dev/detectDesktopOS.js
+++ b/dev/detectDesktopOS.js
@@ -96,22 +96,28 @@ function detectDesktopOS() {
     var osVersion = unknown;
 
     if (/Windows/.test(os)) {
-        osVersion = /Windows (.*)/.exec(os)[1];
+        if (/Windows (.*)/.test(os)) {
+            osVersion = /Windows (.*)/.exec(os)[1];
+        }
         os = 'Windows';
     }
 
     switch (os) {
         case 'Mac OS X':
-            osVersion = /Mac OS X (10[\.\_\d]+)/.exec(nAgt)[1];
+            if (/Mac OS X (10[\.\_\d]+)/.test(nAgt)) {
+                osVersion = /Mac OS X (10[\.\_\d]+)/.exec(nAgt)[1];
+            }
             break;
-
         case 'Android':
-            osVersion = /Android ([\.\_\d]+)/.exec(nAgt)[1];
+            if (/Android ([\.\_\d]+)/.test(nAgt)) {
+                osVersion = /Android ([\.\_\d]+)/.exec(nAgt)[1];
+            }
             break;
-
         case 'iOS':
-            osVersion = /OS (\d+)_(\d+)_?(\d+)?/.exec(nVer);
-            osVersion = osVersion[1] + '.' + osVersion[2] + '.' + (osVersion[3] | 0);
+            if (/OS (\d+)_(\d+)_?(\d+)?/.test(nAgt)) {
+                osVersion = /OS (\d+)_(\d+)_?(\d+)?/.exec(nVer);
+                osVersion = osVersion[1] + '.' + osVersion[2] + '.' + (osVersion[3] | 0);
+            }
             break;
     }
 


### PR DESCRIPTION
Some userAgents are trickier than what is expected here.
try `Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/534.34 (KHTML, like Gecko) PhantomJS/1.9.8 Safari/534.34`
