### PR TITLE
Fixing black background color bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -344,6 +344,7 @@ rtpSenders.replaceTrack(newTrack);';
                     this.parentNode.removeChild(this);
 
                     html2canvas(browserFeaturesTable.parentNode, {
+                        background :'#FFFFFF',
                         grabMouse: false,
                         onrendered: function(canvas) {
                             var image = canvas.toDataURL('image/jpeg');


### PR DESCRIPTION
html2canvas was setting the background to color black, making saved images unreadable.
