### PR TITLE
Catch InvalidState exception raised in Firefox private browsing mode.

### DIFF
--- a/DetectRTC.js
+++ b/DetectRTC.js
@@ -233,6 +233,9 @@
             var db;
             try {
                 db = window.indexedDB.open('test');
+                db.onerror = function() {
+                   return true;
+                }
             } catch (e) {
                 isPrivate = true;
             }


### PR DESCRIPTION
Without the onerror callback in this commit, the check for private state in Firefox private browsing mode raises an exception that is not caught by the try/catch.
