### PR TITLE
Enumerate only the own properties of an object

### DIFF
--- a/dev/detectDesktopOS.js
+++ b/dev/detectDesktopOS.js
@@ -86,10 +86,12 @@ function detectDesktopOS() {
         r: /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/
     }];
     for (var id in clientStrings) {
-        var cs = clientStrings[id];
-        if (cs.r.test(nAgt)) {
-            os = cs.s;
-            break;
+        if (clientStrings.hasOwnProperty(id)) {
+            var cs = clientStrings[id];
+            if (cs.r.test(nAgt)) {
+                os = cs.s;
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes possible "TypeError: undefined is not an object (evaluating 'cs.r.test')"
with extended Array.prototype.