### PR TITLE
Add additional check for MediaStream availability

### DIFF
--- a/DetectRTC.js
+++ b/DetectRTC.js
@@ -1089,7 +1089,7 @@
         MediaStream = webkitMediaStream;
     }
 
-    if (typeof MediaStream !== 'undefined') {
+    if (typeof MediaStream !== 'undefined' && typeof MediaStream === 'function') {
         DetectRTC.MediaStream = Object.keys(MediaStream.prototype);
     } else DetectRTC.MediaStream = false;
 


### PR DESCRIPTION
If the MediaStream object is available an additional check that it is a function is made. Without this check the code will throw a TypeError on iOS since the MediaStream is in fact null.