### PR TITLE
Inform callback whether address is public and ip4/ipv6

### DIFF
--- a/dev/DetectLocalIPAddress.js
+++ b/dev/DetectLocalIPAddress.js
@@ -1,14 +1,25 @@
+
+const regexIpv4Local = /^(192\.168\.|169\.254\.|10\.|172\.(1[6-9]|2\d|3[01]))/,
+      regexIpv4 = /([0-9]{1,3}(\.[0-9]{1,3}){3})/,
+      regexIpv6 = /[a-f0-9]{1,4}(:[a-f0-9]{1,4}){7})/;
+
 // via: https://github.com/diafygi/webrtc-ips
 function DetectLocalIPAddress(callback, stream) {
     if (!DetectRTC.isWebRTCSupported) {
         return;
     }
 
+    var isPublic = true,
+        isIpv4 = true;
     getIPs(function(ip) {
-        if (ip.match(/^(192\.168\.|169\.254\.|10\.|172\.(1[6-9]|2\d|3[01]))/)) {
-            callback('Local: ' + ip);
+        if (ip.match(regexIpv4Local)) {
+            isPublic = false;
+            callback('Local: ' + ip, isPublic, isIpv4);
+        } else if (ip.match(regexIpv6)) { //via https://ourcodeworld.com/articles/read/257/how-to-get-the-client-ip-address-with-javascript-only
+            isIpv4 = false;
+            callback('Public: ' + ip, isPublic, isIpv4);
         } else {
-            callback('Public: ' + ip);
+            callback('Public: ' + ip, isPublic, isIpv4);
         }
     }, stream);
 }
@@ -63,15 +74,16 @@ function getIPs(callback, stream) {
     }
 
     function handleCandidate(candidate) {
-        var ipRegex = /([0-9]{1,3}(\.[0-9]{1,3}){3})/;
-        var match = ipRegex.exec(candidate);
+        var match = regexIpv4.exec(candidate);
         if (!match) {
             return;
         }
         var ipAddress = match[1];
+        const isPublic = (candidate.match(regexIpv4Local)),
+              isIpv4 = true;
 
         if (ipDuplicates[ipAddress] === undefined) {
-            callback(ipAddress);
+            callback(ipAddress, isPublic, isIpv4);
         }
 
         ipDuplicates[ipAddress] = true;


### PR DESCRIPTION
Our webrtc deployments have had problems when the clientside router offers both ipv4 and ipv6. I suggest that DetectRTC surface such info -- we don't need the address itself, so we'd ignore the first callback arg.

Also, just noticed the value on line 82 needs a ! in front.

It would be great if there were an example use of DetectLocalIPAddress.js