### PR TITLE
Fix issue with duplicated devices

### DIFF
--- a/dev/CheckDeviceSupport.js
+++ b/dev/CheckDeviceSupport.js
@@ -77,6 +77,12 @@ function checkDeviceSupport(callback) {
     var alreadyUsedDevices = {};
 
     navigator.enumerateDevices(function(devices) {
+        MediaDevices = [];
+
+        audioInputDevices = [];
+        audioOutputDevices = [];
+        videoInputDevices = [];
+
         devices.forEach(function(_device) {
             var device = {};
             for (var d in _device) {


### PR DESCRIPTION
Fix an issue with duplicated devices being listed on `DetectRTC.MediaDevices`, `DetectRTC.audioInputDevices`, `DetectRTC.audioOutputDevices`, `DetectRTC.videoInputDevices` when calling `DetectRTC.load(callback)` multiple times in a row.