### PR TITLE
Fix typing error TS1046

### DIFF
--- a/DetectRTC.d.ts
+++ b/DetectRTC.d.ts
@@ -7,7 +7,7 @@ interface Device {
   label: string;
 }
 
-namespace DetectRTC {
+declare namespace DetectRTC {
   export function load(callback: () => void): void;
   export const version: string;
   export const osName: string;


### PR DESCRIPTION
Hi there.

When using DetectRTC in an Angular 10 project with Typescript 3.9.7, the typings caused an error (TS1046):
```
ERROR in node_modules/detectrtc/DetectRTC.d.ts:10:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

10 namespace DetectRTC {
   ~~~~~~~~~
```
[It looks like - since TS 0.9 - top level non-interface definitions need to use the "declare" keyword.](https://stackoverflow.com/questions/17635033/error-ts1046-declare-modifier-required-for-top-level-element) This PR simply adds the declare keyword before the namespace definition in the typing file.

I'd appreciate any input if this fix could cause any problems.
Thanks for your work!