### PR TITLE
fix: Firefox Android mic has no device label.

### DIFF
--- a/DetectRTC.js
+++ b/DetectRTC.js
@@ -795,19 +795,11 @@
                             device.label = 'HTTPs is required to get label of this ' + device.kind + ' device.';
                         }
                     }
-                } else {
-                    // Firefox on Android still returns empty label
-                    if (device.kind === 'videoinput' && !isWebsiteHasWebcamPermissions) {
-                        isWebsiteHasWebcamPermissions = true;
-                    }
-
-                    if (device.kind === 'audioinput' && !isWebsiteHasMicrophonePermissions) {
-                        isWebsiteHasMicrophonePermissions = true;
-                    }
                 }
 
                 if (device.kind === 'audioinput') {
                     hasMicrophone = true;
+                    isWebsiteHasMicrophonePermissions = true;
 
                     if (audioInputDevices.indexOf(device) === -1) {
                         audioInputDevices.push(device);
@@ -824,6 +816,7 @@
 
                 if (device.kind === 'videoinput') {
                     hasWebcam = true;
+                    isWebsiteHasWebcamPermissions = true;
 
                     if (videoInputDevices.indexOf(device) === -1) {
                         videoInputDevices.push(device);


### PR DESCRIPTION
On Android Firefox, the `device.label` of a microphone is always an empty string. Even though DetectRTC sets this property, in subsequent calls to `DetectRTC.load` the label is reset to an empty string.

I suggest that the setting of the mic/camera permissions variables should not be dependent on `device.label` being a non-empty string.