### PR TITLE
Declare void return type

### DIFF
--- a/DetectRTC.d.ts
+++ b/DetectRTC.d.ts
@@ -42,7 +42,7 @@ declare namespace DetectRTC {
 
   export const isDesktopCapturingSupported: boolean;
 
-  export function checkWebSocketsSupport(callback: () => void);
+  export function checkWebSocketsSupport(callback: () => void): void;
 
   export const audioInputDevices: Device[]; // microphones
   export const audioOutputDevices: Device[]; // speakers
@@ -67,7 +67,7 @@ declare namespace DetectRTC {
 
   export function DetectLocalIPAddress(
     callback: (localIpAddress: string) => void
-  );
+  ): void;
 
   export const MediaDevices: Device[];
   export const MediaStream: string[];


### PR DESCRIPTION
More specific return type.
I found that while using Angular 12 Typescript checking.

![Screenshot_21](https://user-images.githubusercontent.com/10767151/129469053-a9bb61b0-75f4-4beb-82b7-192f93e85f07.png)
